### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/modules/nixos/amdgpu.nix
+++ b/modules/nixos/amdgpu.nix
@@ -6,7 +6,7 @@ in
   options.miniluz.amdgpu.enable = lib.mkEnableOption "Enable GNOME and GDE";
 
   config = lib.mkIf cfg.enable {
-    # AMD. Source: <https://nixos.wiki/wiki/AMD_GPU>
+    # AMD. Source: <https://wiki.nixos.org/wiki/AMD_GPU>
     services.xserver.videoDrivers = lib.mkIf config.services.xserver.enable [ "amdgpu" ];
 
     systemd.tmpfiles.rules = [

--- a/modules/nixos/obs.nix
+++ b/modules/nixos/obs.nix
@@ -12,7 +12,7 @@ in
     ];
 
     # Sources: 
-    # * <https://nixos.wiki/wiki/PipeWire#Advanced_Configuration>
+    # * <https://wiki.nixos.org/wiki/PipeWire#Advanced_Configuration>
     # * <https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Virtual-devices#virtual-devices>
     services.pipewire.extraConfig.pipewire."91-null-sinks" = {
       "context.objects" = [

--- a/modules/nixos/virt.nix
+++ b/modules/nixos/virt.nix
@@ -7,8 +7,8 @@ in
 
   config = lib.mkIf cfg.enable {
     # Sources:
-    # * <https://nixos.wiki/wiki/Libvirt>
-    # * <https://nixos.wiki/wiki/Virt-manager>
+    # * <https://wiki.nixos.org/wiki/Libvirt>
+    # * <https://wiki.nixos.org/wiki/Virt-manager>
 
     virtualisation.libvirtd = {
       enable = true;


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️